### PR TITLE
Made fixes for RHEL compatibility

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -1,0 +1,107 @@
+# Romifleur Linux Compatibility Fixes
+
+This document covers fixes implemented to resolve crashes and compatibility issues when running Romifleur on certain Linux configurations (ie, RHEL 9).
+
+## The Problem
+
+On some Linux systems—particularly those running X11 with Intel integrated graphics (Alder Lake, Raptor Lake)—the application would crash immediately on startup with errors like:
+
+```
+Error loading logos: PIL.Image and PIL.ImageTk couldn't be imported
+```
+
+```
+X Error of failed request:  BadLength (poly request too large or internal Xlib length error)
+  Major opcode of failed request:  139 (RENDER)
+  Minor opcode of failed request:  20 (RenderAddGlyphs)
+```
+
+## Root Causes
+
+### 1. Missing PIL/Tk Bindings
+
+On RHEL, Fedora, and similar distributions, the `pillow` Python package doesn't include Tk bindings by default. These are provided by a separate system package (`python3-pillow-tk`), which wasn't installed.
+
+### 2. X11 Emoji Rendering Bug
+
+The second error is a known X.org bug that occurs when rendering certain Unicode characters—specifically emoji and special symbols like ⚙️, 🚀, ☐, ☑, ▼, etc. The X server's RENDER extension fails when trying to create glyphs for these characters, crashing the application.
+
+This issue is most common on:
+- X11 (not Wayland)
+- Intel Alder Lake or Raptor Lake integrated graphics
+- Systems without proper emoji font support
+
+## The Solution
+
+### Install PIL/Tk Bindings
+
+For RHEL/Fedora-based systems:
+```bash
+sudo dnf install python3-pillow-tk
+```
+
+For Debian/Ubuntu-based systems:
+```bash
+sudo apt install python3-pil.imagetk
+```
+
+### Automatic Emoji Detection
+
+Rather than removing emoji entirely (which would affect Windows and macOS users... as well as all the fun of having emojis), I implemented some automatic detection. The app **should** now:
+
+1. Check if running on Wayland (which handles emoji fine)
+2. Check for emoji font availability
+3. Detects problematic GPU combinations
+4. Falls back to ASCII characters when emoji rendering would fail
+
+This is handled by the `Icons` class in `src/utils/icons.py`:
+
+```python
+# On systems with emoji support:
+Icons.SETTINGS → "Settings ⚙️"
+Icons.CHECKBOX_CHECKED → "☑"
+
+# On systems without emoji support:
+Icons.SETTINGS → "Settings"
+Icons.CHECKBOX_CHECKED → "[x]"
+```
+
+### X11 Thread Safety
+
+I also tried to account for some threading issued id seen with X11.
+I added X11 initialization fixes in `main.py` that run before any GUI code:
+
+```python
+if platform.system() == "Linux":
+    os.environ.setdefault("FREETYPE_PROPERTIES", "truetype:interpreter-version=35")
+    x11 = ctypes.CDLL("libX11.so.6")
+    x11.XInitThreads()
+```
+
+## Files Modified
+
+- `main.py` — Added X11 workarounds
+- `src/utils/icons.py` — New file for emoji detection and fallback
+- `src/utils/image_utils.py` — Defensive PIL imports
+- `src/ui/components/sidebar.py` — Uses Icons class
+- `src/ui/components/game_list.py` — Uses Icons class
+- `src/ui/components/queue_panel.py` — Uses Icons class
+
+## Manual Override
+
+If you want to force ASCII mode even on systems that pass emoji detection:
+
+```bash
+export ROMIFLEUR_NO_EMOJI=1
+python3 main.py
+```
+
+## Affected Configurations
+
+These fixes specifically address issues seen on:
+- **OS:** RHEL 9.x, Fedora, and similar
+- **Graphics:** Intel Alder Lake-P, Raptor Lake integrated graphics
+- **Display Server:** X11 (Wayland users are unaffected)
+- **Python:** 3.9+
+
+Windows and macOS users should see no change in behavior—they'll continue to see emoji as before.

--- a/main.py
+++ b/main.py
@@ -1,6 +1,24 @@
 import sys
 import os
 import logging
+import platform
+import ctypes
+
+# X11 workarounds for Linux (must be before any tkinter/ctk imports)
+if platform.system() == "Linux":
+    os.environ.setdefault("FREETYPE_PROPERTIES", "truetype:interpreter-version=35")
+    try:
+        x11 = ctypes.CDLL("libX11.so.6")
+        x11.XInitThreads()
+    except Exception:
+        pass
+    
+    # Disable Tk scaling auto-detection that may cause issues
+    try:
+        import customtkinter as ctk
+        ctk.deactivate_automatic_dpi_awareness()
+    except Exception:
+        pass
 
 # Ensure src is in path if needed (though local import should work)
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))

--- a/src/ui/components/game_list.py
+++ b/src/ui/components/game_list.py
@@ -5,6 +5,7 @@ import threading
 import os
 from PIL import Image, ImageTk
 from src.utils.path_utils import resource_path
+from src.utils.icons import Icons
 import platform
 
 class GameList(ctk.CTkFrame):
@@ -116,7 +117,7 @@ class GameList(ctk.CTkFrame):
         self.best_btn = ctk.CTkButton(self.action_frame, text="Load Best Games", fg_color="green", command=self._load_best_games)
         self.best_btn.pack(side="left", padx=10)
         
-        self.add_btn = ctk.CTkButton(self.action_frame, text="Add to Queue ➡️", command=self._add_selected)
+        self.add_btn = ctk.CTkButton(self.action_frame, text=Icons.ARROW_RIGHT, command=self._add_selected)
         self.add_btn.pack(side="right")
         
         ctk.CTkButton(self.action_frame, text="Select All", width=100, fg_color="#444", command=self._toggle_select_all).pack(side="right", padx=10)
@@ -246,7 +247,7 @@ class GameList(ctk.CTkFrame):
                 is_ra = self.app.ra_manager.is_compatible(name, ra_games)
                 img = self.img_trophy if is_ra else self.img_cross
             
-            self.tree.insert("", "end", text="", image=img, values=("☐", name, size))
+            self.tree.insert("", "end", text="", image=img, values=(Icons.CHECKBOX_EMPTY, name, size))
             
         self.info_label.configure(text=f"{len(files)} games found")
         self._update_header_icon()
@@ -267,7 +268,7 @@ class GameList(ctk.CTkFrame):
                 row_id = self.tree.identify_row(event.y)
                 if row_id:
                     vals = self.tree.item(row_id, "values")
-                    new_val = "☑" if vals[0] == "☐" else "☐"
+                    new_val = Icons.CHECKBOX_CHECKED if vals[0] == Icons.CHECKBOX_EMPTY else Icons.CHECKBOX_EMPTY
                     # Preserve Size if it exists (vals might be len 3 now)
                     if len(vals) > 2:
                         self.tree.item(row_id, values=(new_val, vals[1], vals[2]))
@@ -304,7 +305,7 @@ class GameList(ctk.CTkFrame):
         children = self.tree.get_children()
         if not children: return
         first = self.tree.item(children[0], "values")[0]
-        new = "☑" if first == "☐" else "☐"
+        new = Icons.CHECKBOX_CHECKED if first == Icons.CHECKBOX_EMPTY else Icons.CHECKBOX_EMPTY
         for item in children:
             v = self.tree.item(item, "values")
             if len(v) > 2:
@@ -317,7 +318,7 @@ class GameList(ctk.CTkFrame):
         # Check checkboxes
         for item in self.tree.get_children():
             vals = self.tree.item(item, "values")
-            if vals[0] == "☑":
+            if vals[0] == Icons.CHECKBOX_CHECKED:
                 size = vals[2] if len(vals) > 2 else "N/A"
                 items.append((vals[1], size))
         

--- a/src/ui/components/queue_panel.py
+++ b/src/ui/components/queue_panel.py
@@ -5,6 +5,7 @@ import json
 import platform
 import subprocess
 from tkinter import filedialog
+from ...utils.icons import Icons
 
 class QueuePanel(ctk.CTkFrame):
     def __init__(self, master, app_context, **kwargs):
@@ -19,7 +20,7 @@ class QueuePanel(ctk.CTkFrame):
         ctk.CTkLabel(self, text="Download Queue", font=ctk.CTkFont(size=18, weight="bold")).pack(padx=20, pady=20)
         
         # Clear Button (Moved here, above list)
-        ctk.CTkButton(self, text="Clear All 🗑️", fg_color="#AA0000", command=self._clear).pack(padx=20, pady=(0, 10), fill="x")
+        ctk.CTkButton(self, text=Icons.TRASH, fg_color="#AA0000", command=self._clear).pack(padx=20, pady=(0, 10), fill="x")
 
         # List
         self.queue_list = ctk.CTkScrollableFrame(self, label_text="Pending Items")
@@ -42,8 +43,8 @@ class QueuePanel(ctk.CTkFrame):
         io_frame = ctk.CTkFrame(self, fg_color="transparent")
         io_frame.pack(padx=20, pady=(0, 20), fill="x")
         
-        ctk.CTkButton(io_frame, text="Save 💾", width=80, fg_color="#555", command=self._export).pack(side="left", padx=(0, 5), expand=True, fill="x")
-        ctk.CTkButton(io_frame, text="Load 📂", width=80, fg_color="#555", command=self._import).pack(side="left", padx=(5, 0), expand=True, fill="x")
+        ctk.CTkButton(io_frame, text=Icons.SAVE, width=80, fg_color="#555", command=self._export).pack(side="left", padx=(0, 5), expand=True, fill="x")
+        ctk.CTkButton(io_frame, text=Icons.FOLDER, width=80, fg_color="#555", command=self._import).pack(side="left", padx=(5, 0), expand=True, fill="x")
         
         # Open Folder Button (Moved from Sidebar)
         ctk.CTkButton(self, text="Open ROMs Folder", fg_color="#555", command=self._open_roms_folder).pack(padx=20, pady=(10, 20), fill="x")
@@ -74,7 +75,7 @@ class QueuePanel(ctk.CTkFrame):
             item_frame.pack(fill="x", pady=2)
             
             # Remove Button
-            btn = ctk.CTkButton(item_frame, text="❌", width=30, height=20, fg_color="darkred", 
+            btn = ctk.CTkButton(item_frame, text=Icons.REMOVE, width=30, height=20, fg_color="darkred", 
                                 command=lambda idx=i: self._remove(idx))
             btn.pack(side="right", padx=(5, 0))
             

--- a/src/ui/components/sidebar.py
+++ b/src/ui/components/sidebar.py
@@ -2,6 +2,7 @@
 import customtkinter as ctk
 import os
 from ...utils.image_utils import ImageUtils
+from ...utils.icons import Icons
 from .info_panel import InfoPanel
 import platform
 
@@ -27,7 +28,7 @@ class Sidebar(ctk.CTkFrame):
 
 
         # Settings (Bottom)
-        self.settings_btn = ctk.CTkButton(self, text="Settings ⚙️", fg_color="transparent", border_width=1, 
+        self.settings_btn = ctk.CTkButton(self, text=Icons.SETTINGS, fg_color="transparent", border_width=1, 
                                           command=self._open_settings)
         self.settings_btn.pack(side="bottom", padx=20, pady=20, fill="x")
         
@@ -81,12 +82,12 @@ class Sidebar(ctk.CTkFrame):
             btn = self.category_buttons[cat]
             if frame.winfo_viewable():
                 frame.pack_forget()
-                btn.configure(text=f"▶ {cat}")
+                btn.configure(text=f"{Icons.COLLAPSE} {cat}")
             else:
                 frame.pack(fill="x", padx=10, pady=0)
-                btn.configure(text=f"▼ {cat}")
+                btn.configure(text=f"{Icons.EXPAND} {cat}")
 
-        btn = ctk.CTkButton(header_frame, text=f"▼ {category}", fg_color="#333", hover_color="#444", 
+        btn = ctk.CTkButton(header_frame, text=f"{Icons.EXPAND} {category}", fg_color="#333", hover_color="#444", 
                             anchor="w", command=toggle_category, font=("Arial", 13, "bold"))
         btn.pack(fill="x")
         

--- a/src/utils/icons.py
+++ b/src/utils/icons.py
@@ -1,0 +1,82 @@
+"""
+Icon/Emoji support with automatic fallback for X11 compatibility.
+Detects if emoji rendering is likely to work and provides ASCII alternatives.
+"""
+
+import os
+import platform
+import subprocess
+
+
+def _check_emoji_support():
+    """
+    Detect if emoji rendering is likely to work.
+    Returns False for X11 on Linux without proper emoji font support.
+    """
+    if platform.system() != "Linux":
+        return True  # Windows/macOS generally handle emoji fine
+    
+    # Check for manual override
+    if os.environ.get("ROMIFLEUR_NO_EMOJI", "").lower() in ("1", "true", "yes"):
+        return False
+    
+    # Check if running on Wayland (usually better emoji support)
+    session_type = os.environ.get("XDG_SESSION_TYPE", "").lower()
+    if session_type == "wayland":
+        return True
+    
+    # On X11, check for emoji fonts
+    try:
+        result = subprocess.run(
+            ["fc-list", ":charset=1F600"],  # Check for grinning face emoji
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            # Has emoji fonts, but X11 + certain Intel GPUs still have issues
+            # Check for problematic Intel graphics
+            try:
+                lspci = subprocess.run(["lspci"], capture_output=True, text=True, timeout=5)
+                if "Alder Lake" in lspci.stdout or "Raptor Lake" in lspci.stdout:
+                    return False  # Known problematic with X11 emoji rendering
+            except Exception:
+                pass
+            return True
+    except Exception:
+        pass
+    
+    return False  # Default to safe ASCII on X11 Linux
+
+
+EMOJI_SUPPORTED = _check_emoji_support()
+
+
+class Icons:
+    """Icons that fall back to ASCII if emoji not supported."""
+    if EMOJI_SUPPORTED:
+        SETTINGS = "Settings ⚙️"
+        ROCKET = "Start Downloads 🚀"
+        REMOVE = "❌"
+        TROPHY = "🏆"
+        NO_TROPHY = "❌"
+        CHECKBOX_EMPTY = "☐"
+        CHECKBOX_CHECKED = "☑"
+        ARROW_RIGHT = "Add to Queue ➡️"
+        SAVE = "Save 💾"
+        FOLDER = "Load 📂"
+        TRASH = "Clear All 🗑️"
+        EXPAND = "▼"  # Down triangle
+        COLLAPSE = "▶"  # Right triangle
+    else:
+        SETTINGS = "Settings"
+        ROCKET = "Start Downloads"
+        REMOVE = "X"
+        TROPHY = "Y"
+        NO_TROPHY = "-"
+        CHECKBOX_EMPTY = "[ ]"
+        CHECKBOX_CHECKED = "[x]"
+        ARROW_RIGHT = "Add to Queue"
+        SAVE = "Save"
+        FOLDER = "Load"
+        TRASH = "Clear All"
+        EXPAND = "v"
+        COLLAPSE = ">"

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -1,12 +1,24 @@
 
 import os
 import sys
-from PIL import Image, ImageTk
+import logging
+
+# Defensive PIL import
+try:
+    from PIL import Image, ImageTk
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+    logging.warning("PIL.Image and PIL.ImageTk couldn't be imported. Image features disabled.")
+
 import customtkinter as ctk
 
 class ImageUtils:
     @staticmethod
     def load_image(path, size=None):
+        if not PIL_AVAILABLE:
+            return None
+            
         # PyInstaller bundled path fix
         if hasattr(sys, '_MEIPASS'):
             # If path matches an asset, resolve relative to MEIPASS
@@ -24,15 +36,20 @@ class ImageUtils:
                 return ctk.CTkImage(light_image=pil_image, dark_image=pil_image, size=size)
             return ctk.CTkImage(light_image=pil_image, dark_image=pil_image)
         except Exception as e:
-            print(f"Error loading image {path}: {e}")
+            logging.error(f"Error loading image {path}: {e}")
             return None
 
     @staticmethod
     def set_window_icon(window, path):
+        if not PIL_AVAILABLE:
+            return
+            
         if os.path.exists(path):
             try:
                 icon_image = Image.open(path)
                 photo = ImageTk.PhotoImage(icon_image)
                 window.wm_iconphoto(False, photo)
+                # Keep reference to prevent garbage collection
+                window._icon_photo = photo
             except Exception as e:
-                print(f"Error setting icon {path}: {e}")
+                logging.error(f"Error setting icon {path}: {e}")


### PR DESCRIPTION
On some Linux systems—particularly those running X11 with Intel integrated graphics (Alder Lake, Raptor Lake)—the application would crash immediately on startup with errors like:

```
Error loading logos: PIL.Image and PIL.ImageTk couldn't be imported
```

```
X Error of failed request:  BadLength (poly request too large or internal Xlib length error)
  Major opcode of failed request:  139 (RENDER)
  Minor opcode of failed request:  20 (RenderAddGlyphs)
```

[FIXES.md](https://github.com/user-attachments/files/24537958/FIXES.md)
